### PR TITLE
Add Categories Metadata field for each file before uploading

### DIFF
--- a/uploader/serializers.py
+++ b/uploader/serializers.py
@@ -5,7 +5,7 @@ class FileSerializer(serializers.Serializer):
     name = fields.CharField(allow_blank=True)
     id = fields.CharField(allow_blank=True)
     description = fields.CharField(max_length=200, allow_blank=True, allow_null=True)
-
+    categories = fields.CharField(max_length=200, allow_blank=True, allow_null=True)
 
 class GooglePhotosUploadInputSerializer(serializers.Serializer):
     fileList = FileSerializer(many=True)


### PR DESCRIPTION
"Categories" metadata field is added so that the user can select the category to which the image belongs to before the user uploads the images to Wikimedia commons
![image](https://user-images.githubusercontent.com/46782283/77002453-8c136380-6981-11ea-89db-d1adbaeb751f.png)
