### PR TITLE
After login, Displaying folders and images for user to select #33

### DIFF
--- a/uploader/templates/upload.html
+++ b/uploader/templates/upload.html
@@ -272,7 +272,7 @@
   function createPicker() {
     if (pickerApiLoaded && oauthToken) {
       var view = new google.picker.DocsView().setIncludeFolders(true);
-      view.setMimeTypes("");
+      view.setMimeTypes("image/jpeg,image/jpg,image/gif,image/png,image/bmp");
       var picker = new google.picker.PickerBuilder()
         .enableFeature(google.picker.Feature.NAV_HIDDEN)
         .enableFeature(google.picker.Feature.MULTISELECT_ENABLED)

--- a/uploader/templates/upload.html
+++ b/uploader/templates/upload.html
@@ -271,8 +271,8 @@
   // Create and render a Picker object for searching images.
   function createPicker() {
     if (pickerApiLoaded && oauthToken) {
-      var view = new google.picker.View(google.picker.ViewId.DOCS);
-      view.setMimeTypes("image/png,image/jpeg,image/jpg");
+      var view = new google.picker.DocsView().setIncludeFolders(true);
+      view.setMimeTypes("");
       var picker = new google.picker.PickerBuilder()
         .enableFeature(google.picker.Feature.NAV_HIDDEN)
         .enableFeature(google.picker.Feature.MULTISELECT_ENABLED)


### PR DESCRIPTION
In the tool, after selecting the "choose photos from google drive" button, images are displayed in a random order and this pull request fixes this issue. Folders are first displayed after selecting "choose photos from google drive" button as shown below.

![image](https://user-images.githubusercontent.com/46782283/77800858-b6f66980-709d-11ea-9e8b-87f4f7936476.png)

Then we can navigate through folders and view files and sub folders as shown below

![image](https://user-images.githubusercontent.com/46782283/77800949-e4431780-709d-11ea-9595-40de6e834437.png)

To view only images after navigating to a folder, select file type as images from advanced search options as shown below

![image](https://user-images.githubusercontent.com/46782283/77801455-e5c10f80-709e-11ea-94b9-8eb9c8cb514d.png)

![image](https://user-images.githubusercontent.com/46782283/77801467-efe30e00-709e-11ea-8ace-d6a11259ed9a.png)

Then select the images to upload to Wikimedia commons. We can select multiple images randomly by selecting the images while pressing the CTRL button as shown below. This Fixes tonythomas01/gdrive-to-commons-repo#34

![image](https://user-images.githubusercontent.com/46782283/77801560-1ef97f80-709f-11ea-8bcc-ee66c307c39f.png)

After this we can upload the images to Wikimedia commons. 



Fixes tonythomas01/gdrive-to-commons-repo#33